### PR TITLE
Added support for Dask Dataframe chunks.

### DIFF
--- a/qarray/df_test.py
+++ b/qarray/df_test.py
@@ -5,7 +5,7 @@ import dask.dataframe as dd
 import numpy as np
 import xarray as xr
 
-from .df import explode, to_dd
+from .df import explode, to_dd, block_slices
 
 
 class DaskTestCase(unittest.TestCase):
@@ -64,6 +64,14 @@ class DaskDataframeTest(DaskTestCase):
     df: dd.DataFrame = to_dd(self.air_small).compute()
     types = list(df.dtypes)
     self.assertEqual([self.air_small[c].dtype for c in df.columns], types)
+
+  def test_partitions_dont_match_dataset_chunks(self):
+    standard_blocks = list(block_slices(self.air_small))
+    default: dd.DataFrame = to_dd(self.air_small)
+    chunked: dd.DataFrame = to_dd(self.air_small, dict(time=5))
+
+    self.assertEqual(default.npartitions, len(standard_blocks))
+    self.assertNotEqual(chunked.npartitions, len(standard_blocks))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Users can specify chunks to break up the Xarray Dataset that may differ from the Dataset's own chunking mechanism. This is useful, for example, when working with Zarr. Here, you can set the Zarr chunks to be big and the unravel chunks to be small (more partitions in the resulting DataFrame). This can help limit the overall memory copying during unraveling.