### PR TITLE
Simplifying unravel logic

### DIFF
--- a/perf_tests/compute_air.py
+++ b/perf_tests/compute_air.py
@@ -8,6 +8,6 @@ if __name__ == '__main__':
   chunks = {'time': 240}
   air = air.chunk(chunks)
 
-  df = qr.to_dd(air).compute()
+  df = qr.read_xarray(air).compute()
 
   print(len(df))

--- a/perf_tests/groupby_air.py
+++ b/perf_tests/groupby_air.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     time=slice(0, 12), lat=slice(0, 11), lon=slice(0, 10)
   ).chunk(chunks)
 
-  df = qr.to_dd(air_small)
+  df = qr.read_xarray(air_small)
 
   c = Context()
   c.create_table('air', df)

--- a/perf_tests/groupby_air_full.py
+++ b/perf_tests/groupby_air_full.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
   chunks = {'time': 240}
   air = air.chunk(chunks)
 
-  df = qr.to_dd(air)
+  df = qr.read_xarray(air)
 
   c = Context()
   c.create_table('air', df)

--- a/perf_tests/open_era5.py
+++ b/perf_tests/open_era5.py
@@ -8,6 +8,6 @@ era5_ds = xr.open_zarr(
   'gs://gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2',
   chunks={'time': 240, 'level': 1}
 )
-era5_wind_df = qr.to_dd(era5_ds[['u_component_of_wind', 'v_component_of_wind']])
+era5_wind_df = qr.read_xarray(era5_ds[['u_component_of_wind', 'v_component_of_wind']])
 
 print(era5_wind_df.columns)

--- a/perf_tests/sanity.py
+++ b/perf_tests/sanity.py
@@ -11,6 +11,6 @@ if __name__ == '__main__':
     time=slice(0, 12), lat=slice(0, 11), lon=slice(0, 10)
   ).chunk(chunks)
 
-  df = qr.to_dd(air_small).compute()
+  df = qr.read_xarray(air_small).compute()
 
   print(len(df))

--- a/qarray/__init__.py
+++ b/qarray/__init__.py
@@ -1,3 +1,2 @@
-from .core import unravel
-from .df import to_dd
+from .df import read_xarray
 

--- a/qarray/core.py
+++ b/qarray/core.py
@@ -2,7 +2,6 @@ import itertools
 import typing as t
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 Row = t.List[t.Any]
@@ -12,6 +11,7 @@ def get_columns(ds: xr.Dataset) -> t.List[str]:
   return list(ds.dims.keys()) + list(ds.data_vars.keys())
 
 
+# Deprecated
 def unravel(ds: xr.Dataset) -> t.Iterator[Row]:
   dim_keys, dim_vals = zip(*ds.dims.items())
 
@@ -23,6 +23,7 @@ def unravel(ds: xr.Dataset) -> t.Iterator[Row]:
     yield row
 
 
+# Deprecated
 def unbounded_unravel(ds: xr.Dataset) -> np.ndarray:
   """Unravel with unbounded memory (as a NumPy Array)."""
   dim_keys, dim_vals = zip(*ds.dims.items())

--- a/qarray/df_integration_test.py
+++ b/qarray/df_integration_test.py
@@ -2,7 +2,7 @@ import unittest
 
 import xarray as xr
 
-from .df import to_dd
+from . import read_xarray
 
 
 class Era5TestCast(unittest.TestCase):
@@ -11,7 +11,7 @@ class Era5TestCast(unittest.TestCase):
       'gs://gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2',
       chunks={'time': 240, 'level': 1}
     )
-    era5_wind_df = to_dd(era5_ds[['u_component_of_wind', 'v_component_of_wind']])
+    era5_wind_df = read_xarray(era5_ds[['u_component_of_wind', 'v_component_of_wind']])
 
     self.assertEqual(list(era5_wind_df.columns), [
       'time', 'level', 'latitude', 'longitude',

--- a/qarray/df_test.py
+++ b/qarray/df_test.py
@@ -5,7 +5,7 @@ import dask.dataframe as dd
 import numpy as np
 import xarray as xr
 
-from .df import explode, to_dd, block_slices
+from .df import explode, read_xarray, block_slices
 
 
 class DaskTestCase(unittest.TestCase):
@@ -53,30 +53,30 @@ class ExplodeTest(DaskTestCase):
 class DaskDataframeTest(DaskTestCase):
 
   def test_sanity(self):
-    df = to_dd(self.air_small).compute()
+    df = read_xarray(self.air_small).compute()
     self.assertIsNotNone(df)
     self.assertEqual(len(df), np.prod(list(self.air_small.dims.values())))
 
   def test_columns(self):
-    df = to_dd(self.air_small).compute()
+    df = read_xarray(self.air_small).compute()
     cols = list(df.columns)
     self.assertEqual(cols, ['lat', 'time', 'lon', 'air'])
 
   def test_dtypes(self):
-    df: dd.DataFrame = to_dd(self.air_small).compute()
+    df: dd.DataFrame = read_xarray(self.air_small).compute()
     types = list(df.dtypes)
     self.assertEqual([self.air_small[c].dtype for c in df.columns], types)
 
   def test_partitions_dont_match_dataset_chunks(self):
     standard_blocks = list(block_slices(self.air_small))
-    default: dd.DataFrame = to_dd(self.air_small)
-    chunked: dd.DataFrame = to_dd(self.air_small, dict(time=5))
+    default: dd.DataFrame = read_xarray(self.air_small)
+    chunked: dd.DataFrame = read_xarray(self.air_small, dict(time=5))
 
     self.assertEqual(default.npartitions, len(standard_blocks))
     self.assertNotEqual(chunked.npartitions, len(standard_blocks))
 
   def test_chunk_perf(self):
-    df = to_dd(self.air, chunks=dict(time=6)).compute()
+    df = read_xarray(self.air, chunks=dict(time=6)).compute()
     self.assertIsNotNone(df)
     self.assertEqual(len(df), np.prod(list(self.air.dims.values())))
 

--- a/qarray/sql_test.py
+++ b/qarray/sql_test.py
@@ -2,13 +2,13 @@ import unittest
 
 from dask_sql import Context
 
-from .df import to_dd
+from . import read_xarray
 from .df_test import DaskTestCase
 
 
 class SqlTestCase(DaskTestCase):
   def test_sanity(self):
-    df = to_dd(self.air_small)
+    df = read_xarray(self.air_small)
 
     c = Context()
     c.create_table('air', df)
@@ -20,7 +20,7 @@ class SqlTestCase(DaskTestCase):
     self.assertEqual(len(result), 100)
 
   def test_agg_small(self):
-    df = to_dd(self.air_small)
+    df = read_xarray(self.air_small)
 
     c = Context()
     c.create_table('air', df)
@@ -41,7 +41,7 @@ class SqlTestCase(DaskTestCase):
     self.assertEqual(len(result), expected)
 
   def slow_test_agg_regular(self):
-    df = to_dd(self.air)
+    df = read_xarray(self.air)
 
     c = Context()
     c.create_table('air', df)


### PR DESCRIPTION
There are some major changes here: 
- Using Xarray's built-in dataframe conversion
- Renames: `to_dd` is now `read_xarray`. `f` is now `pivot`. 
- Deletion of `to_pd`, which is no longer needed IMO. 
- Added deprecation comment to my core `unravel` functions.