### PR TITLE
Lazy read_xarray with iterables and parsing metadata.

### DIFF
--- a/xarray_sql/df.py
+++ b/xarray_sql/df.py
@@ -86,10 +86,7 @@ def from_map_batched(
     args = ()
 
   def map_batches():
-    print('entering map_batched')
-    for i, items in enumerate(zip(*iterables)):
-      if i % 100 == 0:
-        print(f'item {i} in map_batches')
+    for items in zip(*iterables):
       df = func(*items, *args, **kwargs)
       yield pa.RecordBatch.from_pandas(df, schema=schema)
 

--- a/xarray_sql/df.py
+++ b/xarray_sql/df.py
@@ -149,6 +149,7 @@ def pivot(ds: xr.Dataset) -> pd.DataFrame:
   """Converts an xarray Dataset to a pandas DataFrame."""
   return ds.to_dataframe().reset_index()
 
+
 def _parse_schema(ds) -> pa.Schema:
   """Extracts a `pa.Schema` from the Dataset, treating dims and data_vars as columns."""
   columns = []
@@ -158,7 +159,7 @@ def _parse_schema(ds) -> pa.Schema:
     if coord_name in ds.dims:
       pa_type = pa.from_numpy_dtype(coord_var.dtype)
       columns.append(pa.field(coord_name, pa_type))
-  
+
   for var_name, var in ds.data_vars.items():
     pa_type = pa.from_numpy_dtype(var.dtype)
     columns.append(pa.field(var_name, pa_type))
@@ -178,6 +179,7 @@ def read_xarray(ds: xr.Dataset, chunks: Chunks = None) -> pa.RecordBatchReader:
   Returns:
     A PyArrow Table, which is a table representation of the input Dataset.
   """
+
   def pivot_block(b: Block):
     return pivot(ds.isel(b))
 

--- a/xarray_sql/df.py
+++ b/xarray_sql/df.py
@@ -167,13 +167,12 @@ def read_xarray(ds: xr.Dataset, chunks: Chunks = None) -> pa.RecordBatchReader:
       da.dims == fst for da in ds.values()
   ), "All dimensions must be equal. Please filter data_vars in the Dataset."
 
-  blocks = list(block_slices(ds, chunks))
+  blocks = block_slices(ds, chunks)
 
   def pivot_block(b: Block):
     return pivot(ds.isel(b))
 
-  schema = pa.Schema.from_pandas(pivot_block(blocks[0]))
-  last_schema = pa.Schema.from_pandas(pivot_block(blocks[-1]))
-  assert schema == last_schema, "Schemas must be consistent across blocks!"
-
-  return from_map_batched(pivot_block, blocks, schema=schema)
+  head, *tail = blocks
+  schema = pa.Schema.from_pandas(pivot_block(head))
+  joined = itertools.chain([head], tail)
+  return from_map_batched(pivot_block, joined, schema=schema)


### PR DESCRIPTION
I no longer convert the block_slices iterables into a list. I've also implemented a quick `_parse_schema` method to extract the `pa.Schema` from the dataset without materializing the first block. These should provide a few good performance improvements for working with real datasets.