### PR TITLE
docs: add quickstart and note gcsfs requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,48 @@ SQL queries against them.
 
 ## Quickstart
 
-Open any Xarray Dataset, register it as a table with `from_dataset`, then query
-it with `sql`:
+Open a Dataset, register it as a table with `from_dataset`, compute a
+climatology in SQL, then write the result back to Xarray and plot it:
+
+> **Note:** this example also needs `pooch` and a netCDF backend (for the
+> tutorial download) and `matplotlib` (for the plot):
+> `pip install pooch netCDF4 matplotlib`.
 
 ```python
 import xarray as xr
 import xarray_sql as xql
 
-# A small tutorial dataset, downloaded once via `pooch`.
+# 4x-daily surface air temperature on a lat/lon grid, 2013-2014.
 ds = xr.tutorial.open_dataset('air_temperature')
 
 ctx = xql.XarrayContext()
-ctx.from_dataset('air', ds, chunks=dict(time=10))
+ctx.from_dataset('air', ds, chunks=dict(time=100))
 
-ctx.sql('SELECT MAX(air) FROM air')
-# max(air.air)
-# --
-# 317.40000000000003
+# A climatology — the long-term mean at each grid cell — computed in SQL.
+clim = ctx.sql('''
+  SELECT "lat", "lon", AVG("air") AS air
+  FROM "air"
+  GROUP BY "lat", "lon"
+''')
+
+# Write the SQL result back to an Xarray Dataset. Because `time` was
+# aggregated away, name the remaining dimensions explicitly. The variable's
+# source metadata (e.g. its units) is recovered from the registered table.
+clim_ds = clim.to_dataset(dims=["lat", "lon"])
+# <xarray.Dataset>
+# Dimensions:  (lat: 25, lon: 53)
+# Coordinates:
+#   * lat      (lat) float32 75.0 72.5 70.0 ... 20.0 17.5 15.0
+#   * lon      (lon) float32 200.0 202.5 205.0 ... 325.0 327.5 330.0
+# Data variables:
+#     air      (lat, lon) float64 ...
+
+# Plot the climatology like any other Dataset.
+clim_ds["air"].plot()  # in a script, call matplotlib.pyplot.show() to display
 ```
 
-That's the whole loop. Everything below is the same three steps —
-`XarrayContext`, `from_dataset`, `sql` — at a larger scale.
+That's the round trip — Xarray in, SQL in the middle, Xarray (and a plot) back
+out.
 
 ## A bigger example: ARCO-ERA5
 

--- a/README.md
+++ b/README.md
@@ -36,26 +36,23 @@ ds = xr.tutorial.open_dataset('air_temperature')
 ctx = xql.XarrayContext()
 ctx.from_dataset('air', ds, chunks=dict(time=100))
 
-# A climatology — the long-term mean at each grid cell — computed in SQL.
+# A climatology — the mean annual cycle — computed in SQL: average air
+# temperature for each month of the year, over all grid cells and years.
 clim = ctx.sql('''
-  SELECT "lat", "lon", AVG("air") AS air
+  SELECT
+    CAST(date_part('month', "time") AS INTEGER) AS month,
+    AVG("air") AS air
   FROM "air"
-  GROUP BY "lat", "lon"
+  GROUP BY CAST(date_part('month', "time") AS INTEGER)
+  ORDER BY month
 ''')
 
-# Write the SQL result back to an Xarray Dataset. Because `time` was
-# aggregated away, name the remaining dimensions explicitly. The variable's
-# source metadata (e.g. its units) is recovered from the registered table.
-clim_ds = clim.to_dataset(dims=["lat", "lon"])
-# <xarray.Dataset>
-# Dimensions:  (lat: 25, lon: 53)
-# Coordinates:
-#   * lat      (lat) float32 75.0 72.5 70.0 ... 20.0 17.5 15.0
-#   * lon      (lon) float32 200.0 202.5 205.0 ... 325.0 327.5 330.0
-# Data variables:
-#     air      (lat, lon) float64 ...
+# Write the SQL result back to an Xarray Dataset. `month` is a derived
+# column, so name it as the dimension; the variable's units are recovered
+# from the registered table. The result is one value per month: air(month).
+clim_ds = clim.to_dataset(dims=["month"])
 
-# Plot the climatology like any other Dataset.
+# Plot the annual cycle as a time series.
 clim_ds["air"].plot()  # in a script, call matplotlib.pyplot.show() to display
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ pip install xarray-sql
 ## What is this?
 
 This is an experiment to provide a SQL interface for array datasets.
+Succinctly, we "pivot" Xarray Datasets to treat them like tables so we can run
+SQL queries against them.
+
+## Quickstart
+
+Open any Xarray Dataset, register it as a table with `from_dataset`, then query
+it with `sql`:
+
+```python
+import xarray as xr
+import xarray_sql as xql
+
+# A small tutorial dataset, downloaded once via `pooch`.
+ds = xr.tutorial.open_dataset('air_temperature')
+
+ctx = xql.XarrayContext()
+ctx.from_dataset('air', ds, chunks=dict(time=10))
+
+ctx.sql('SELECT MAX(air) FROM air')
+# max(air.air)
+# --
+# 317.40000000000003
+```
+
+That's the whole loop. Everything below is the same three steps —
+`XarrayContext`, `from_dataset`, `sql` — at a larger scale.
+
+## A bigger example: ARCO-ERA5
+
+The same interface scales to cloud-native datasets with hundreds of variables,
+like [ARCO-ERA5](https://github.com/google-research/arco-era5).
+
+> **Note:** reading from `gs://` requires `gcsfs` (`pip install gcsfs`).
 
 ```python
 import xarray as xr
@@ -104,9 +137,6 @@ ctx.sql('''
 
 _(A runnable version of this example lives at
 [`perf_tests/era5_temp_profile.py`](perf_tests/era5_temp_profile.py).)_
-
-Succinctly, we "pivot" Xarray Datasets to treat them like tables so we can run
-SQL queries against them. 
 
 ## Why build this?
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,13 @@
 # Examples
 
+A query result can be consumed two ways: as a flat pandas DataFrame
+(`to_pandas`) or written back to an Xarray Dataset (`to_dataset`). This computes
+a climatology — the long-term mean at each grid cell — and shows both.
+
+> **Note:** this example also needs `pooch` and a netCDF backend (for the
+> tutorial download) and `matplotlib` (for the plot):
+> `pip install pooch netCDF4 matplotlib`.
+
 ```python
 import xarray as xr
 import xarray_sql as xql
@@ -7,19 +15,25 @@ import xarray_sql as xql
 ds = xr.tutorial.open_dataset('air_temperature')
 
 ctx = xql.XarrayContext()
-ctx.from_dataset('air', ds, chunks=dict(time=24))
+ctx.from_dataset('air', ds, chunks=dict(time=100))
 
-result = ctx.sql('''
+clim = ctx.sql('''
   SELECT
-    "lat", "lon", AVG("air") as air_avg
+    "lat", "lon", AVG("air") AS air
   FROM
     "air"
   GROUP BY
-   "lat", "lon"
+    "lat", "lon"
 ''')
 
-df = result.to_pandas()
-df.head()
+# Option 1: a flat pandas DataFrame.
+clim.to_pandas().head()
+
+# Option 2: round-trip back to an Xarray Dataset and plot it. `time` was
+# aggregated away, so name the remaining dimensions explicitly; the variable's
+# units are recovered from the registered table.
+clim_ds = clim.to_dataset(dims=["lat", "lon"])
+clim_ds["air"].plot()
 ```
 
 ## Mixed-dimension datasets: ARCO-ERA5

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -35,6 +35,8 @@ Open a year of ARCO-ERA5 and let SQL `WHERE` clauses do the filtering — the
 library prunes time partitions and pushes dimension-column filters down. Use
 the `table_names` kwarg to give each dimension group a friendly name:
 
+> **Note:** reading from `gs://` requires `gcsfs` (`pip install gcsfs`).
+
 ```python
 import xarray as xr
 import xarray_sql as xql

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,8 @@
 
 A query result can be consumed two ways: as a flat pandas DataFrame
 (`to_pandas`) or written back to an Xarray Dataset (`to_dataset`). This computes
-a climatology — the long-term mean at each grid cell — and shows both.
+a climatology — the mean annual cycle, one value per month of the year — and
+shows both.
 
 > **Note:** this example also needs `pooch` and a netCDF backend (for the
 > tutorial download) and `matplotlib` (for the plot):
@@ -19,20 +20,23 @@ ctx.from_dataset('air', ds, chunks=dict(time=100))
 
 clim = ctx.sql('''
   SELECT
-    "lat", "lon", AVG("air") AS air
+    CAST(date_part('month', "time") AS INTEGER) AS month,
+    AVG("air") AS air
   FROM
     "air"
   GROUP BY
-    "lat", "lon"
+    CAST(date_part('month', "time") AS INTEGER)
+  ORDER BY
+    month
 ''')
 
 # Option 1: a flat pandas DataFrame.
 clim.to_pandas().head()
 
-# Option 2: round-trip back to an Xarray Dataset and plot it. `time` was
-# aggregated away, so name the remaining dimensions explicitly; the variable's
-# units are recovered from the registered table.
-clim_ds = clim.to_dataset(dims=["lat", "lon"])
+# Option 2: round-trip back to an Xarray Dataset and plot the annual cycle as
+# a time series. `month` is a derived column, so name it as the dimension; the
+# variable's units are recovered from the registered table.
+clim_ds = clim.to_dataset(dims=["month"])
 clim_ds["air"].plot()
 ```
 


### PR DESCRIPTION
- Add a short, dependency-light Quickstart (air_temperature + MAX) near
  the top of the README so the first example is fast to read and run, and
  demote the heavy ARCO-ERA5 walkthrough to 'A bigger example'.
- Note that the gs:// ARCO-ERA5 example requires gcsfs, in both the
  README and docs/examples.md.

Closes #184
Closes #185


```python
import xarray as xr
import xarray_sql as xql

ds = xr.tutorial.open_dataset('air_temperature')

ctx = xql.XarrayContext()
ctx.from_dataset('air', ds, chunks=dict(time=100))

clim = ctx.sql('''
  SELECT
    CAST(date_part('month', "time") AS INTEGER) AS month,
    AVG("air") AS air
  FROM
    "air"
  GROUP BY
    CAST(date_part('month', "time") AS INTEGER)
  ORDER BY
    month
''')

# Option 1: a flat pandas DataFrame.
clim.to_pandas().head()

# Option 2: round-trip back to an Xarray Dataset and plot the annual cycle as
# a time series. `month` is a derived column, so name it as the dimension; the
# variable's units are recovered from the registered table.
clim_ds = clim.to_dataset(dims=["month"])
clim_ds["air"].plot()
```

<img width="600" height="429" alt="image" src="https://github.com/user-attachments/assets/eaeca35b-ad8b-4ce5-94b3-a421a0dbd29a" />
