### PR TITLE
Add TEM benchmark (case 10): zonal means + eddy fluxes as a GROUP BY

### DIFF
--- a/benchmarks/geospatial/10_tem.py
+++ b/benchmarks/geospatial/10_tem.py
@@ -1,0 +1,164 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "xarray-sql",
+#   "xarray",
+#   "gcsfs",
+#   "zarr>=3",
+# ]
+#
+# [tool.uv.sources]
+# xarray-sql = { path = "../../", editable = true }
+# ///
+"""Transformed Eulerian Mean: zonal means and eddy fluxes are a GROUP BY.
+
+The Transformed Eulerian Mean (TEM) is a standard atmospheric-circulation
+diagnostic: average the flow around each latitude circle, then measure how the
+departures from that average (the eddies) carry momentum and heat. In the array
+paradigm it is ``ds.mean("longitude")`` plus a few ``(x - x_bar)`` products
+averaged again over longitude.
+
+Every piece of that is relational. A zonal mean is ``GROUP BY latitude``
+collapsing longitude. An eddy flux such as the momentum flux
+``u'v' = mean((u - u_bar)(v - v_bar))`` is, by the covariance identity, just
+``AVG(u*v) - AVG(u)*AVG(v)``: one grouped pass, no self-join. So the whole
+diagnostic is::
+
+    SELECT time, level, latitude,
+           AVG(u) AS u_bar, ...,
+           AVG(u*v) - AVG(u)*AVG(v) AS upvp,   -- eddy momentum flux u'v'
+           AVG(v*t) - AVG(v)*AVG(t) AS vptp,   -- eddy heat flux v't'
+           AVG(u*w) - AVG(u)*AVG(w) AS upwp    -- vertical momentum flux u'w'
+    FROM era5 GROUP BY time, level, latitude
+
+This is the diagnostic dcherian raised in the Large Scale Geospatial Benchmarks
+discussion (coiled/benchmarks #1545); the SQL reads like its textbook definition.
+
+Dataset: the full ARCO-ERA5 archive (0.25 degree, 37 pressure levels), opened
+lazily, so the query reads only u, v, T, w on the requested levels and timestep.
+Validated against the same diagnostic computed in pure xarray.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import xarray as xr
+
+import xarray_sql as xql
+
+from _harness import (
+    CaseSkipped,
+    assert_grid_close,
+    measured,
+    run_case,
+    show_result,
+    show_sql,
+    timed,
+)
+
+_URL = "gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3"
+_T = datetime.datetime(2020, 6, 1, 12)
+# Three representative pressure levels (hPa): upper jet, mid, lower troposphere.
+_LEVELS = (250, 500, 850)
+_VARS = [
+    "u_component_of_wind",
+    "v_component_of_wind",
+    "temperature",
+    "vertical_velocity",
+]
+# Timestep and levels are bound as query parameters, not formatted into the SQL.
+_PARAMS = {"t": _T, "l1": _LEVELS[0], "l2": _LEVELS[1], "l3": _LEVELS[2]}
+
+
+def main() -> None:
+    try:
+        import gcsfs  # noqa: F401  (required by the gs:// protocol)
+
+        ds = xr.open_zarr(_URL, chunks=None, storage_options={"token": "anon"})
+    except Exception as exc:  # noqa: BLE001  (any failure skips, not crash)
+        raise CaseSkipped(f"ARCO-ERA5 unavailable ({exc})") from exc
+
+    print(
+        f"  ARCO-ERA5: {ds.sizes['time']:,} timesteps x {ds.sizes['level']} levels "
+        f"x {ds.sizes['latitude']}x{ds.sizes['longitude']} (no pre-slicing)"
+    )
+
+    ctx = xql.XarrayContext()
+    with timed("register full ERA5 (lazy)"):
+        ctx.from_dataset(
+            "era5",
+            ds,
+            chunks={"time": 1},
+            table_names={
+                ("time", "latitude", "longitude"): "surface",
+                ("time", "level", "latitude", "longitude"): "atmosphere",
+            },
+        )
+
+    sql = """
+        WITH f AS (
+            SELECT time, level, latitude,
+                   "u_component_of_wind" AS u,
+                   "v_component_of_wind" AS v,
+                   "temperature"         AS t,
+                   "vertical_velocity"   AS w
+            FROM era5.atmosphere
+            WHERE time = $t
+              AND level IN ($l1, $l2, $l3)
+        )
+        SELECT time, level, latitude,
+               AVG(u) AS u_bar,
+               AVG(v) AS v_bar,
+               AVG(t) AS t_bar,
+               AVG(w) AS w_bar,
+               AVG(u * v) - AVG(u) * AVG(v) AS upvp,
+               AVG(v * t) - AVG(v) * AVG(t) AS vptp,
+               AVG(u * w) - AVG(u) * AVG(w) AS upwp
+        FROM f
+        GROUP BY time, level, latitude
+        ORDER BY time, level, latitude
+    """
+    show_sql(sql)
+
+    # Round-trip the diagnostic to a (time, level, latitude) Dataset.
+    for _ in measured("SQL TEM (zonal means + eddy covariances, lazy read)"):
+        got = ctx.sql(sql, param_values=_PARAMS).to_dataset(
+            dims=["time", "level", "latitude"]
+        )
+
+    # Array reference: the same TEM diagnostic in pure xarray.
+    for _ in measured("xarray reference"):
+        sub = ds[_VARS].sel(time=[_T], level=list(_LEVELS))
+        u, v, t, w = (sub[n] for n in _VARS)
+
+        def zm(x: xr.DataArray) -> xr.DataArray:
+            return x.mean("longitude")
+
+        u_bar, v_bar, t_bar, w_bar = zm(u), zm(v), zm(t), zm(w)
+        ref_upvp = zm((u - u_bar) * (v - v_bar))
+        ref_vptp = zm((v - v_bar) * (t - t_bar))
+        ref_upwp = zm((u - u_bar) * (w - w_bar))
+
+    # Tolerance covers the SQL one-pass covariance (AVG(u*v) - AVG(u)*AVG(v))
+    # against the two-pass xarray reference on float32 ERA5 fields.
+    assert_grid_close(
+        "zonal-mean u (u_bar)", got.u_bar, u_bar, rtol=1e-3, atol=1e-2
+    )
+    assert_grid_close(
+        "eddy momentum flux u'v'", got.upvp, ref_upvp, rtol=1e-3, atol=1e-2
+    )
+    assert_grid_close(
+        "eddy heat flux v't'", got.vptp, ref_vptp, rtol=1e-3, atol=1e-2
+    )
+    assert_grid_close(
+        "vertical flux u'w'", got.upwp, ref_upwp, rtol=1e-3, atol=1e-2
+    )
+
+    show_result(got)
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        run_case(main, "TEM: zonal means + eddy fluxes as GROUP BY (ARCO-ERA5)")
+    )

--- a/benchmarks/geospatial/README.md
+++ b/benchmarks/geospatial/README.md
@@ -24,6 +24,7 @@ plain-English definition of the operation, and computes the same numbers.
 | 07 | `07_reproject_udf.py` | per-pixel CRS transform | scalar **UDF** (`reproject()`), à la PostGIS `ST_Transform` |
 | 08 | `08_regrid_weights.py` | interpolation to a new grid | sparse-weight table `JOIN` + weighted `GROUP BY` |
 | 09 | `09_warp.py` | reproject **and** resample (warp) | reproject **UDF** (07) → weight table `JOIN` (08) |
+| 10 | `10_tem.py` | zonal means + eddy fluxes (TEM diagnostic) | `GROUP BY (time, level, lat)` + covariance `AVG(u*v) - AVG(u)*AVG(v)` |
 
 Cases 01–06 show operations that are *natively* relational. Cases 07–08 are the
 "hardest" array operations — reprojection and regridding — and show where a UDF
@@ -31,6 +32,9 @@ fits (a per-row coordinate transform) versus where the operation is really a
 sparse matrix multiply expressed as a `JOIN`. Case 09 composes the two into a full
 **warp** (GDAL/rasterio `reproject`): the 07 UDF reprojects the target grid, arrays
 turn the reprojected points into bilinear weights, and the 08 `JOIN` applies them.
+Case 10 returns to a pure reduction: the Transformed Eulerian Mean, where the
+zonal means and the eddy momentum and heat fluxes fall out of a single grouped
+aggregate via the covariance identity.
 See
 [`docs/geospatial.md`](../../docs/geospatial.md) for the full narrative,
 including *where the array paradigm still earns its keep* (generating the
@@ -60,6 +64,9 @@ interpolation weights — the geometry — which SQL applies but does not comput
   validates against xarray's `.interp()` at the reprojected points, with Earth
   Engine's own lon/lat SRTM as a second, cross-CRS check. All three run against
   Earth Engine using your existing `gcloud` login, and skip cleanly without it.
+- **10 TEM** uses the same **ARCO-ERA5** archive as 02-06, reading the atmospheric
+  wind and temperature fields (u, v, T, w) on a few pressure levels for one
+  timestep. Network-backed; skips cleanly offline.
 
 ## Running
 


### PR DESCRIPTION
Adds `10_tem.py`: the Transformed Eulerian Mean (zonal means plus the eddy momentum, heat, and vertical fluxes) as one grouped aggregate, using the covariance identity `AVG(u*v) - AVG(u)*AVG(v)` so there is no self-join.
Reads u/v/T/w lazily from ARCO-ERA5 on three pressure levels and asserts the result matches the same diagnostic in pure xarray; the TEM workflow dcherian raised in #1545.

```text
  ⏱  SQL TEM (zonal means + eddy covariances, lazy read): 197.715s  (peak 892.3 MB)
  ⏱  xarray reference: 240.136s  (peak 395.0 MB)
  ✅ zonal-mean u (u_bar): SQL matches xarray reference (n=2,163, coordinate-aligned)
  ✅ eddy momentum flux u'v': SQL matches xarray reference (n=2,163, coordinate-aligned)
  ✅ eddy heat flux v't': SQL matches xarray reference (n=2,163, coordinate-aligned)
  ✅ vertical flux u'w': SQL matches xarray reference (n=2,163, coordinate-aligned)

  Result (SQL -> xarray):
  <xarray.Dataset> Size: 124kB
  Dimensions:   (time: 1, level: 3, latitude: 721)
  Coordinates:
    * time      (time) datetime64[ns] 2020-06-01T12:00:00
    * level     (level) int64 250 500 850
    * latitude  (latitude) float32 -90.0 -89.75 ... 89.75 90.0
  Data variables: u_bar, v_bar, t_bar, w_bar, upvp (u'v'), vptp (v't'), upwp (u'w')

  🎉 TEM: zonal means + eddy fluxes as GROUP BY (ARCO-ERA5): done.
```
