### PR TITLE
Build abi3 wheels so installs don't recompile on macOS/Windows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,6 +195,10 @@ jobs:
   upload-to-pypi:
     needs: verify-built-dist
     runs-on: ubuntu-latest
+    # Only publish for real releases. `workflow_dispatch` runs build and
+    # verify the wheels (uploaded as artifacts) without pushing to PyPI, so
+    # the workflow can be exercised manually without cutting a release.
+    if: github.event_name == 'release'
     steps:
       - uses: actions/download-artifact@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,9 @@ jobs:
           manylinux: 2_28
           rustup-components: rust-std rustfmt
           sccache: 'true'
-          args: --release --strip --out dist -i python3.10 python3.11 python3.12 python3.13
+          # abi3 (see Cargo.toml) produces one wheel for all CPython >= 3.10,
+          # so a single interpreter is enough to build it.
+          args: --release --strip --out dist -i python3.10
 
       - uses: actions/upload-artifact@v6
         with:
@@ -113,7 +115,9 @@ jobs:
           manylinux: 2_28
           rustup-components: rust-std rustfmt
           sccache: 'true'
-          args: --release --strip --out dist -i python3.10 python3.11 python3.12 python3.13
+          # abi3 (see Cargo.toml) produces one wheel for all CPython >= 3.10,
+          # so a single interpreter is enough to build it.
+          args: --release --strip --out dist -i python3.10
 
       - uses: actions/upload-artifact@v6
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xarray_sql"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ async-trait = "0.1"
 datafusion = { version = "52.0.0" }
 datafusion-ffi = { version = "52.0.0" }
 futures = { version = "0.3" }
-pyo3 = { version = "0.26.0", features = ["extension-module"] }
+# `abi3-py310` builds against CPython's stable ABI, so a single wheel per
+# platform works on all CPython >= 3.10 (matching `requires-python`). This
+# lets the release workflow ship pre-built wheels for every interpreter
+# without compiling per-version, avoiding local rebuilds on install.
+pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py310"] }
 tokio = { version = "1.46.1", features = ["rt"] }
 
 


### PR DESCRIPTION
## Problem

Installing on macOS (and Windows) triggers a full local Rust compilation instead of using a pre-built wheel — see #163. On an M1 Mac with Python 3.12/3.13, `uv`/`pip` find no matching wheel and fall back to building the whole datafusion/arrow/pyo3 stack from the sdist.

Root cause: PyPI only had `cp311` wheels for macOS/Windows, while Linux had `cp310`–`cp313`:

```
cp311-cp311-macosx_11_0_arm64.whl   ← only Python 3.11
cp311-cp311-win_amd64.whl           ← only Python 3.11
cp310/311/312/313 ...manylinux...   ← all versions (built with -i in maturin-action)
```

The mac/win job in `publish.yml` runs a bare `maturin build`, which only targets the runner's single interpreter (3.11, from `.python-version`). The manylinux jobs avoided this by enumerating interpreters with `-i python3.10 python3.11 python3.12 python3.13`.

## Fix

Enable PyO3's stable ABI (`abi3-py310`) — the same approach [datafusion-python](https://github.com/apache/datafusion-python) uses for this exact pyo3 + arrow + datafusion-ffi stack. Each platform now ships a single `cpXX-abi3` wheel that installs on **all CPython ≥ 3.10**, including future versions. This closes the per-version coverage gap and collapses 12+ wheels into 5.

- **`Cargo.toml`** — add `abi3-py310` to pyo3's features. maturin auto-detects abi3 and tags wheels `cp310-abi3`. No change needed to the mac/win job.
- **`publish.yml`** — manylinux jobs no longer need to enumerate interpreters; one `-i python3.10` produces the abi3 wheel.
- **`publish.yml`** — gate `upload-to-pypi` on `github.event_name == 'release'` so the workflow can be run via `workflow_dispatch` to build/verify wheels as artifacts **without** an irreversible PyPI publish. (Previously a manual dispatch would have published.)

## Verification

- `cargo check` with `abi3-py310`: passes — the extension uses only abi3-safe APIs (`pyclass`, `pymethods`, `PyCapsule`, `extract`, `try_iter`).
- `maturin build --release`: produced `xarray_sql-0.3.0-cp310-abi3-manylinux_2_34_x86_64.whl` (single abi3 wheel, was `cp311-cp311` before).
- Installed that 3.10-tagged wheel into a clean **Python 3.11** venv with `--only-binary :all:` (compilation forbidden) and imported the native module successfully — proving cross-version install with no rebuild.

CI (`ci-build.yml`) will exercise `maturin build` with abi3 on macOS, Windows, and Linux runners.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDK8JtQyRQDdwJMgqADbe5)_